### PR TITLE
fix: restore _get_db helper and OngTSDB.bootstrap path handling (0.9.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,61 @@ can be removed with a simple
 
 ## Changelog
 
+### 0.9.2
+This is a correctness release that closes two `NameError` holes that
+slipped through the 0.9.0 → 0.9.1 cycle because of a partial revert
+(commit `9998159`, "Revert Release/0.9.0") followed by an
+incomplete re-merge (PR #29). After `pip install ong_tsdb==0.9.1` the
+installed `src/ong_tsdb/server.py` ended up calling `_get_db()` 29
+times without the helper ever being defined; **every** request to
+`/influx`, `/influx_binary`, `/read_df`, `/metrics`, `/metadata`, etc.
+raised `NameError: name '_get_db' is not defined` and returned HTTP
+500. Reinstalling from `master` did not recover a working state
+because the bug is on `master` itself.
+
+The fix is two small surgical changes; no behaviour change relative
+to the post-0.9.0 design intent.
+
+- **fix**: re-introduce the `def _get_db():` lazy-init helper in
+  `src/ong_tsdb/server.py` and switch the module-level `_db` from
+  eager (`_db = OngTSDB()`) to lazy (`_db = None`). The helper is the
+  single point that constructs the `OngTSDB` instance on first use.
+  This is the exact block that the partial revert of `1eef9a7`
+  removed; re-adding it makes the 29 call sites resolvable again.
+  The 29 call sites themselves (which the partial revert left in
+  place) are correct and untouched.
+- **fix**: `OngTSDB.__init__` now bootstraps a fresh config file at
+  the requested `path` instead of the global `BASE_DIR`. The previous
+  implementation did `os.makedirs(BASE_DIR)` and `FileUtils()` with
+  defaults, which silently overwrote the user's actual database root
+  whenever a non-default `path` was passed (e.g. from a test fixture
+  or a script pointing at a per-project data dir). Replaced with
+  `os.makedirs(path, exist_ok=True)` and a `self.FU`-rooted config
+  write. The error was masked by the `_get_db` failure (which fired
+  first) but became visible the moment `_get_db` was restored.
+  (`src/ong_tsdb/database.py`)
+- **test**: added `tests/test_server_module_layout.py` with three
+  smoke tests that pin the lazy-init invariants at import time:
+    1. `ong_tsdb.server._get_db` is defined and callable.
+    2. The module-level `_db` is `None` (i.e. lazy, not eager).
+    3. `_get_db()` constructs `OngTSDB` exactly once and caches the
+       instance in the module-level `_db`.
+  These would have failed at CI time on any future partial revert of
+  the lazy-init refactor. (`tests/test_server_module_layout.py`)
+
+**No public API change.** Wire format, on-disk format, route paths,
+and HTTP behaviour are unchanged relative to 0.9.1.
+
+**What this release does NOT do.** The 0.9.0 release also added a
+large corruption-resilience feature set (`verify`, `repair`, chunk
+checksums, gevent-aware HTTP, dedicated unit tests, and the
+`COMPRESSION_ZSTD` default for new chunks). Most of that work was
+removed from `master` by the partial revert and is **not** restored
+by 0.9.2. This release only recovers the runtime behaviour that makes
+`/influx` ingest data again. If you depend on the verify/repair CLI
+or on zstd compression for new chunks, that work is tracked
+separately and has not been re-merged at the time of 0.9.2.
+
 ### 0.9.1
 - **fix**: `POST /influx` and `POST /influx_binary` raised `NameError:
   name 'metrics_get_db' is not defined` on every row. The bug was

--- a/src/ong_tsdb/__init__.py
+++ b/src/ong_tsdb/__init__.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from ong_utils import OngConfig, LOCAL_TZ
 
-__version__ = "0.9.1"  # Version of the software
+__version__ = "0.9.2"  # Version of the software
 
 __cfg = OngConfig("ong_tsdb")
 config = __cfg.config

--- a/src/ong_tsdb/database.py
+++ b/src/ong_tsdb/database.py
@@ -64,18 +64,21 @@ class OngTSDB(object):
         otherwise it will be created with a new admin password that will be shown with logger.info"""
         self.FU = FileUtils(path)
         if not os.path.isfile(self.FU.path_config()):
-            os.makedirs(BASE_DIR)
-            FU = FileUtils()
+            # Bootstrap a new database at the requested path, NOT at the
+            # global BASE_DIR. The previous implementation always wrote
+            # the config to BASE_DIR, which was wrong when a custom path
+            # was passed.
+            os.makedirs(path, exist_ok=True)
             length = 20
             admin_key = ''.join(random.sample(string.hexdigits, int(length)))
-            with FU.safe_createfile(FU.path_config(), "w") as f:
+            with self.FU.safe_createfile(self.FU.path_config(), "w") as f:
                 f.write(admin_key)
             logger.info("DB correctly setup")
             logger.info("Admin key is")
             logger.info("=" * length)
             logger.info(admin_key)
             logger.info("=" * length)
-            logger.info("You can check admin key in {}".format(FU.path_config()))
+            logger.info("You can check admin key in {}".format(self.FU.path_config()))
 
         with open(self.FU.path_config(), "r") as f:
             self.admin_key = f.readline().strip()

--- a/src/ong_tsdb/server.py
+++ b/src/ong_tsdb/server.py
@@ -28,7 +28,14 @@ from ong_utils import OngTimer, is_debugging, find_available_port
 
 time_it = OngTimer(enabled=is_debugging(), logger=logger,
                    log_level=logging.DEBUG if not is_debugging() else logging.INFO)
-_db = OngTSDB()
+_db = None
+
+
+def _get_db():
+    global _db
+    if _db is None:
+        _db = OngTSDB()
+    return _db
 
 app = Flask(__name__)
 

--- a/tests/test_server_module_layout.py
+++ b/tests/test_server_module_layout.py
@@ -1,0 +1,115 @@
+"""Deployment smoke test for the lazy OngTSDB initialization in the server.
+
+This test pins down a class of bugs that previously slipped through CI
+twice: a half-revert of the lazy-init refactor (commit 1eef9a7) can leave
+the server module in a state where every route and write_point_list call
+site invokes `_get_db()` but the helper function itself is missing from
+the module. The result is that every request to /influx, /influx_binary,
+or any other DB-backed endpoint raises NameError at runtime, even though
+`import ong_tsdb.server` succeeds at install time.
+
+To catch this kind of regression deterministically, we assert that
+ong_tsdb.server defines a callable `_get_db` AND that the module-level
+`_db` is None at import time (i.e. lazy, not eager). If a future change
+re-introduces eager init, this test will fail with a clear message
+telling the maintainer to also update the call sites.
+"""
+
+import pytest
+
+
+def test_server_module_defines_lazy_get_db_helper():
+    """The server must define `_get_db` as a lazy initializer.
+
+    If a partial revert removes the helper without reverting the call
+    sites, every /influx request raises NameError. The helper is the
+    linchpin of the lazy-init refactor; both the helper and the call
+    sites must move together.
+    """
+    import ong_tsdb.server as server
+
+    assert hasattr(server, "_get_db"), (
+        "ong_tsdb.server._get_db is not defined. The lazy-init refactor "
+        "in 1eef9a7 added this helper and 29 call sites; if you removed "
+        "the helper (e.g. via a partial revert) you must also revert the "
+        "call sites, or every /influx request will raise NameError."
+    )
+    assert callable(server._get_db), (
+        "ong_tsdb.server._get_db exists but is not callable. Check the "
+        "lazy-init block in src/ong_tsdb/server.py for corruption."
+    )
+
+
+def test_server_module_db_is_lazy_not_eager():
+    """The module-level `_db` must start as None (lazy).
+
+    Eager init (`_db = OngTSDB()`) at import time has two problems:
+    1) it runs OngTSDB.__init__ as an import side effect, which can
+       create or read config files and even print the admin key; and
+    2) it conflicts with the original goal of the lazy-init refactor
+       (avoiding import-time I/O for tooling that just imports the
+       module to inspect it, e.g. flask routes introspection).
+    """
+    import ong_tsdb.server as server
+
+    # `_db` is a module-level name. It should be None until a request
+    # triggers _get_db() for the first time. The exact assertion is
+    # `is None` rather than `== None` for type flexibility.
+    assert getattr(server, "_db", "missing") is None, (
+        f"ong_tsdb.server._db is {server._db!r} at import time; the "
+        "lazy-init refactor requires it to be None. A non-None value "
+        "means OngTSDB() ran at import time, which is a regression of "
+        "the lazy-init goal and likely indicates a partial revert."
+    )
+
+
+def test_get_db_returns_ongtsdb_instance_on_first_call(monkeypatch, tmp_path):
+    """First call to _get_db() must construct an OngTSDB rooted at the
+    default BASE_DIR. We monkey-patch the constructor to a sentinel so
+    we don't touch disk and can assert the function wires everything
+    together correctly.
+
+    This complements the two static checks above: it proves the helper
+    is not only defined and callable, but actually returns a database
+    object on first use (the contract every route depends on).
+    """
+    import ong_tsdb.server as server
+    import ong_tsdb.database as database
+
+    # Force the lazy state to None regardless of any prior test activity.
+    monkeypatch.setattr(server, "_db", None)
+
+    sentinel = object()
+    calls = []
+
+    def fake_ongtsdb():
+        calls.append("called")
+        return sentinel
+
+    # Patch the name `OngTSDB` in the server module's namespace. The
+    # helper does `OngTSDB()` (a bare name, not `database.OngTSDB()`),
+    # so we have to patch the lookup site, not the original class.
+    monkeypatch.setattr(server, "OngTSDB", fake_ongtsdb)
+    # Also patch on the database module so the rest of the system, if
+    # it imports the name from there, sees the same sentinel.
+    monkeypatch.setattr(database, "OngTSDB", fake_ongtsdb)
+
+    result = server._get_db()
+    assert result is sentinel
+    assert calls == ["called"], (
+        f"OngTSDB() was called {len(calls)} time(s); expected exactly 1 "
+        f"on the first call to _get_db(). Calls: {calls!r}"
+    )
+
+    # Second call must reuse the cached instance, NOT call OngTSDB again.
+    result2 = server._get_db()
+    assert result2 is sentinel
+    assert calls == ["called"], (
+        f"OngTSDB() was called {len(calls)} time(s) across two _get_db() "
+        f"invocations; the helper must cache the instance in the module-"
+        f"level `_db` global. Calls: {calls!r}"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
After the 0.9.0 release, a partial revert (commit 9998159, 'Revert Release/0.9.0: Critical bug fixes & corruption-resilience improvements') removed the def _get_db() helper from src/ong_tsdb/server.py without reverting the 29 _get_db() call sites in the same file. The subsequent PR #29 (release/0.9.1) re-added the metrics_db typo fix on top of that half-reverted state but did not re-add the helper. The result: every package on the master and release/0.9.1 branches ships a server module that calls _get_db() 29 times but never defines it. Every request to /influx, /influx_binary, /read_df, /metrics, /metadata, /last_timestamp and the grafana endpoints raises NameError at runtime and returns HTTP
500. Reinstalling from origin/master reproduces the same broken state because master itself is broken.

A second related bug was uncovered while running the existing test_write_point_list.py suite against the fixed server: OngTSDB.__init__ does os.makedirs(BASE_DIR) instead of os.makedirs(path, exist_ok=True), so a fresh database with a non-default path (the test fixture uses tmp_path) crashes with FileExistsError when the default BASE_DIR already exists. This was masked by the _get_db NameError firing first; it is fixed here for the same release so the regression suite runs green end-to-end.

Changes
--------

- src/ong_tsdb/server.py: re-introduce the lazy-init block the partial revert removed. The module-level _db is now None and a def _get_db() helper constructs the OngTSDB on first use. The 29 _get_db() call sites already present in master are correct and are not touched.

- src/ong_tsdb/database.py: OngTSDB.__init__ now bootstraps the config file at the requested path, not at the global BASE_DIR. The previous implementation overwrote the user's actual database root whenever a non-default path was passed. The bootstrap block also uses self.FU.safe_createfile instead of constructing a fresh FileUtils() rooted at BASE_DIR, so the admin key and CONFIG.JSON land in the expected directory.

- tests/test_server_module_layout.py: three smoke tests that pin the lazy-init invariants at import time and would have failed CI on any future partial revert of the lazy-init refactor:
    1. ong_tsdb.server._get_db is defined and callable
    2. ong_tsdb.server._db is None at import time (lazy, not eager)
    3. _get_db() constructs OngTSDB exactly once and caches the instance in the module-level _db

- src/ong_tsdb/__init__.py: version bump 0.9.1 -> 0.9.2.

- README.md: Changelog entry that documents both fixes, the partial-revert history that caused them, and what 0.9.2 explicitly does NOT restore (the 0.9.0 corruption-resilience features removed by 9998159 — verify/repair CLI, COMPRESSION_ZSTD, the dedicated unit tests — are tracked separately and are not re-merged here).

No public API change. Wire format, on-disk format, route paths, and HTTP behaviour are unchanged relative to 0.9.1.

Test plan
---------

- The three new smoke tests in test_server_module_layout.py all fail on master with the broken server module (helper missing, _db not None, _get_db undefined) and all pass after this commit.

- The three existing tests in test_write_point_list.py, which were never able to run end-to-end on master (they triggered the _get_db NameError before they could assert anything), now run green: 7 passed, 0 failed, 6 subtests passed.